### PR TITLE
Update to TeXLive 2025

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "LaTeX Environment",
-  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2023c-debian",
+  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025-debian",
   
   "remoteUser": "node",
   


### PR DESCRIPTION
## Summary
- Update devcontainer image from TeXLive 2023c to TeXLive 2025
- Provides latest LaTeX packages and improved compilation environment

## Changes
- `.devcontainer/devcontainer.json`: Update container image tag from `2023c-debian` to `2025-debian`

## Test plan
- [ ] Verify devcontainer builds successfully with new TeXLive 2025 image
- [ ] Test LaTeX compilation with sample documents
- [ ] Confirm Japanese language support remains functional

🤖 Generated with [Claude Code](https://claude.ai/code)