### PR TITLE
Cleanup: Revert test version to production

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "LaTeX Environment",
-  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025c-test",
+  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025b",
   
   "remoteUser": "node",
   


### PR DESCRIPTION
This PR reverts the test version (2025c-test) back to the current production version (2025b).

## Changes
- Reverted `.devcontainer/devcontainer.json` from test version `2025c-test` to production version `2025b`

## Why
- The test version was used to verify the create-release workflow functionality
- Testing is complete and successful, so we should restore the production version
- This ensures the repository is in a clean state for actual texlive updates