### PR TITLE
Track CLAUDE.md in git and add MCP tools guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,9 +244,16 @@ Templates (sotsuron-template, wr-template, etc.)
 - Update dependent templates as needed
 - Coordinate with ecosystem maintainers
 
-## Shell Command Gotchas
+## MCP Tools Usage
 
-### Backticks in gh pr create/edit
+### GitHub Operations
+Use MCP tools instead of `gh` command for GitHub operations:
+- **Development**: Use `mcp__gh-toshi__*` tools for development work
+- **Student testing**: Use `mcp__gh-k19__*` tools only when testing student workflows
+
+### Shell Command Gotchas
+
+#### Backticks in gh pr create/edit
 When using `gh pr create` or `gh pr edit` with `--body`, backticks (`) in the body text are interpreted as command substitution by the shell. This causes errors like:
 ```
 permission denied: .devcontainer/devcontainer.json


### PR DESCRIPTION
## Summary

Resolves #57 by enhancing CLAUDE.md with MCP tools usage guidelines for better team collaboration.

## Changes Made

### MCP Tools Documentation
- **Development workflow**: Use `mcp__gh-toshi__*` tools for development work  
- **Student testing**: Use `mcp__gh-k19__*` tools only when testing student workflows
- **Clear separation**: Prevents confusion between development and testing environments

### Documentation Improvements  
- **Better organization**: Improved structure of shell command gotchas section
- **Comprehensive guidance**: Enhanced Claude instructions for consistent development practices

## Benefits

✅ **Team Collaboration**: Shared Claude context across all developers  
✅ **Consistent Workflows**: Clear guidelines for MCP tool usage  
✅ **Version Control**: Track changes to development instructions over time  
✅ **Reduced Errors**: Prevent mixing development and student testing tools

## Technical Details

### MCP Tools Strategy
```
Development work: mcp__gh-toshi__* tools
Student testing:  mcp__gh-k19__* tools
```

This separation ensures:
- Development work uses appropriate permissions
- Student workflow testing is isolated
- No accidental operations on wrong accounts

## Compatibility

No breaking changes. This enhances existing CLAUDE.md with additional guidance.