### PR TITLE
Update dependency check schedule to JST 09:00

### DIFF
--- a/.github/workflows/check-texlive-updates.yml
+++ b/.github/workflows/check-texlive-updates.yml
@@ -6,8 +6,8 @@ name: Check TeXLive Updates
 
 on:
   schedule:
-    # Run daily at 9:00 UTC (18:00 JST)
-    - cron: '0 9 * * *'
+    # Run daily at 0:00 UTC (9:00 JST)
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,9 +244,16 @@ Templates (sotsuron-template, wr-template, etc.)
 - Update dependent templates as needed
 - Coordinate with ecosystem maintainers
 
-## Shell Command Gotchas
+## MCP Tools Usage
 
-### Backticks in gh pr create/edit
+### GitHub Operations
+Use MCP tools instead of `gh` command for GitHub operations:
+- **Development**: Use `mcp__gh-toshi__*` tools for development work
+- **Student testing**: Use `mcp__gh-k19__*` tools only when testing student workflows
+
+### Shell Command Gotchas
+
+#### Backticks in gh pr create/edit
 When using `gh pr create` or `gh pr edit` with `--body`, backticks (`) in the body text are interpreted as command substitution by the shell. This causes errors like:
 ```
 permission denied: .devcontainer/devcontainer.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,18 +224,40 @@ npx textlint --print-config
 ## Ecosystem Integration
 
 ### Related Repositories
-- **texlive-ja-textlint**: Base Docker image
-- **sotsuron-template**: Uses this environment
-- **latex-release-action**: CI/CD integration
-- **aldc**: Deploys this environment
+
+#### Core Infrastructure
+- **texlive-ja-textlint**: Base Docker image with LaTeX + textlint
+- **latex-release-action**: GitHub Action for automated LaTeX compilation
+- **aldc**: Command-line tool for deploying this environment
+
+#### Templates Using This Environment
+- **sotsuron-template**: Unified thesis template (undergraduate/graduate)
+- **ise-report-template**: Information Science Exercise HTML reports with textlint
+- **wr-template**: Weekly report template
+- **latex-template**: Basic LaTeX template
+- **sotsuron-report-template**: Report template for thesis work
+
+#### Supporting Tools
+- **ai-academic-paper-reviewer**: AI-powered academic paper review GitHub Action
+- **thesis-management-tools**: Administrative tools and workflows
 
 ### Dependency Chain
 ```
-texlive-ja-textlint (Docker image)
+texlive-ja-textlint (Docker base)
     ↓
-latex-environment (this repository)
+latex-environment (this repository - DevContainer template)
     ↓
-Templates (sotsuron-template, wr-template, etc.)
+├── sotsuron-template (LaTeX thesis)
+├── ise-report-template (HTML reports with textlint)
+├── wr-template (Weekly reports)
+├── latex-template (Basic LaTeX)
+└── sotsuron-report-template (Thesis reports)
+
+Supporting Infrastructure:
+├── latex-release-action → (Used by LaTeX templates)
+├── ai-academic-paper-reviewer → (Used by thesis repos)
+├── aldc → (Deploys this environment)
+└── thesis-management-tools → (Management workflows)
 ```
 
 ### Version Coordination


### PR DESCRIPTION
## 概要

GitHub Actionsのtexlive-ja-textlint依存関係チェックのスケジュールを日本時間09:00に変更します。

## 変更内容

- cronスケジュールを `0 9 * * *` (UTC 09:00 = JST 18:00) から `0 0 * * *` (UTC 00:00 = JST 09:00) に変更
- コメントも更新して正しい時刻を反映

## 理由

- 日本の業務時間内（朝）に依存関係の更新を確認できる
- 問題があった場合、当日中に対応可能
- 夕方実行より朝の方が、その日の作業計画に組み込みやすい

## テスト

- cron式の構文は正しい
- GitHub Actionsのスケジュール設定として有効