### PR TITLE
Change dependency check schedule to 10:00 JST for testing

### DIFF
--- a/.github/workflows/check-texlive-updates.yml
+++ b/.github/workflows/check-texlive-updates.yml
@@ -6,8 +6,8 @@ name: Check TeXLive Updates
 
 on:
   schedule:
-    # Run daily at 0:00 UTC (9:00 JST)
-    - cron: '0 0 * * *'
+    # Run daily at 1:00 UTC (10:00 JST)
+    - cron: '0 1 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 目的

修正されたワークフローの動作テストのため、一時的にスケジュールを変更します。

## 変更内容

- cronスケジュールを `0 0 * * *` (UTC 00:00 = JST 09:00) から `0 1 * * *` (UTC 01:00 = JST 10:00) に変更
- コメントも更新

## テスト計画

1. **約1時間後の10:00に実行**
2. **期待される動作**: `2025b` → `2025c` への更新PR自動作成
3. **確認ポイント**:
   - 正しい最新バージョン(`2025c`)を検出
   - 重複PRを作成しない
   - ブランチ名の衝突を回避

## 修正内容

前回の失敗を受けて以下を修正済み:
- ✅ タグのコミット日時による正確なバージョン検出
- ✅ タイムスタンプ付きブランチ名で衝突回避
- ✅ 重複PR防止ロジック

## 後続作業

テスト成功後、スケジュールを09:00に戻す予定です。