### PR TITLE
Update texlive-ja-textlint to 2025

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   // Compatible with texlive-ja-textlint: 2025b (TeXLive 2025)
   // See VERSIONS.md for compatibility matrix
   "name": "LaTeX Environment",
-  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025b",
+  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025",
   
   "remoteUser": "node",
   

--- a/.github/workflows/check-texlive-updates.yml
+++ b/.github/workflows/check-texlive-updates.yml
@@ -119,7 +119,7 @@ jobs:
           sed -i 's|"image": "ghcr.io/smkwlab/texlive-ja-textlint:[^"]*"|"image": "ghcr.io/smkwlab/texlive-ja-textlint:${{ steps.check.outputs.latest_tag }}"|' .devcontainer/devcontainer.json
           
           # Update the container image in workflow files
-          find .github/workflows -name "*.yml" -o -name "*.yaml" | xargs sed -i 's|container: ghcr.io/smkwlab/texlive-ja-textlint:[^[:space:]]*|container: ghcr.io/smkwlab/texlive-ja-textlint:${{ steps.check.outputs.latest_tag }}|g'
+          find .github/workflows -name "*.yml" -o -name "*.yaml" | xargs sed -i 's|container: ghcr.io/smkwlab/texlive-ja-textlint:2025 ghcr.io/smkwlab/texlive-ja-textlint:${{ steps.check.outputs.latest_tag }}|g'
           
           # Commit the changes
           git add .devcontainer/devcontainer.json .github/workflows/

--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build-and-release-pdf:
     runs-on: ubuntu-latest
-    container: ghcr.io/smkwlab/texlive-ja-textlint:2025b
+    container: ghcr.io/smkwlab/texlive-ja-textlint:2025
     steps:
       - uses: smkwlab/latex-release-action@v2.2.0
         with:


### PR DESCRIPTION
## ❌ 間違った更新方向のためクローズ

このPRは `2025b` → `2025` への更新ですが、これは間違った方向です。

### 正しい状況
- **実際の最新版**: `2025c` (2025-06-16)
- **現在使用中**: `2025b`
- **必要な更新**: `2025b` → `2025c`

### 問題の原因
ワークフローのバージョン検出ロジックが、アノテーテッドタグ `2025` を最新と誤認識していました。

### 対処方法
1. PR #68でバージョン検出ロジックを修正
2. 修正後に正しい `2025b` → `2025c` 更新PRを再作成

---
*このPRは自動的にクローズされました。PR #68の修正が適用された後、正しい更新PRが作成される予定です。*