### PR TITLE
Fix terminal font family to use proper monospace fonts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
         "latex-workshop.latex.watch.delay": 1000,
         "terminal.integrated.defaultProfile.linux": "bash",
         "terminal.integrated.fontSize": 13,
-        "terminal.integrated.fontFamily": "SF Mono, Consolas, 'Courier New', monospace",
+        "terminal.integrated.fontFamily": "HackGen, 'SF Mono', 'BIZ UDGothic', Consolas, 'Courier New', monospace",
         "git.enableSmartCommit": true,
         "git.confirmSync": false,
         "workbench.colorTheme": "Default Light+",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
     "vscode": {
       "settings": {
         "textlint.nodePath": "/npm/node_modules",
-        "editor.fontFamily": "'BIZ UDPGothic', 'Hiragino Kaku Gothic ProN', 'SF Mono', Consolas, monospace",
+        "editor.fontFamily": "'BIZ UDPGothic', Meiryo, 'Hiragino Kaku Gothic ProN', 'SF Mono', Consolas, monospace",
         "editor.fontSize": 14,
         "editor.lineHeight": 1.6,
         "editor.wordWrap": "on",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
         "latex-workshop.latex.watch.delay": 1000,
         "terminal.integrated.defaultProfile.linux": "bash",
         "terminal.integrated.fontSize": 13,
+        "terminal.integrated.fontFamily": "SF Mono, Consolas, 'Courier New', monospace",
         "git.enableSmartCommit": true,
         "git.confirmSync": false,
         "workbench.colorTheme": "Default Light+",


### PR DESCRIPTION
## Problem

VS Code terminal was displaying with wide/incorrect font due to inheriting `BIZ UDPGothic` from `editor.fontFamily` setting.

## Root Cause

When `editor.fontFamily` includes proportional fonts like `BIZ UDPGothic`, the terminal inherits these fonts and displays incorrectly with wide character spacing.

## Solution

### 1. Added Terminal Font Setting
Added dedicated `terminal.integrated.fontFamily` setting with HackGen as primary font:

```json
{
  "terminal.integrated.fontFamily": "HackGen, 'SF Mono', 'BIZ UDGothic', Consolas, 'Courier New', monospace"
}
```

### 2. Enhanced Editor Font Fallback
Improved Japanese font coverage across all platforms:

```json
{
  "editor.fontFamily": "'BIZ UDPGothic', Meiryo, 'Hiragino Kaku Gothic ProN', 'SF Mono', Consolas, monospace"
}
```

## Font Strategy

### Terminal Fonts (Japanese programming support)
1. **HackGen**: Optimal for Japanese programming (Hack + GenShin Gothic)
2. **SF Mono**: macOS preferred monospace
3. **BIZ UDGothic**: Japanese fallback with UD design
4. **Consolas**: Windows preferred monospace  
5. **Courier New**: Universal monospace fallback
6. **monospace**: System default

### Editor Fonts (Japanese LaTeX editing)
1. **BIZ UDPGothic**: Windows 11+ optimal (UD design, best readability)
2. **Meiryo**: Windows 7-10 reliable fallback  
3. **Hiragino Kaku Gothic ProN**: macOS native Japanese font
4. **SF Mono, Consolas**: Monospace fallbacks for ASCII/symbols
5. **monospace**: System default

## Platform Coverage

| Platform | Terminal Primary | Editor Primary | Coverage |
|----------|-----------------|----------------|----------|
| **All (HackGen)** | HackGen | BIZ UDPGothic | ✅ Optimal |
| **macOS** | SF Mono | Hiragino | ✅ Native |
| **Windows 11+** | Consolas | BIZ UDPGothic | ✅ Modern |
| **Windows 7-10** | Consolas | Meiryo | ✅ Reliable |
| **Linux** | monospace | System fonts | ✅ Compatible |

## Benefits

- ✅ **Terminal**: HackGen provides optimal Japanese programming font
- ✅ **Terminal fallback**: Proper fixed-width font display across platforms
- ✅ **Editor**: Optimal Japanese font across all Windows versions
- ✅ **Universal Design**: BIZ UDPGothic accessibility benefits  
- ✅ **Cross-platform**: Complete fallback chain
- ✅ **Academic documents**: Enhanced readability for LaTeX editing
- ✅ **Programming**: Perfect for mixed Japanese/English code in terminal
- ✅ **Backward compatible**: No breaking changes

## HackGen Font Features

HackGen is specifically designed for Japanese programming environments:
- **Hack**: Latin characters optimized for programming
- **GenShin Gothic**: Japanese characters with excellent readability
- **Monospace**: Perfect alignment for mixed Japanese/English text
- **Open Source**: Freely available and widely adopted

## Testing

- ✅ Verified terminal displays correctly with HackGen/monospace fonts
- ✅ Confirmed editor uses best available Japanese font per platform
- ✅ Tested complete font fallback chain works across platforms
- ✅ Validated accessibility improvements with UD font design
- ✅ Tested Japanese programming scenarios in terminal