### PR TITLE
Update to texlive-ja-textlint:2025e for ecosystem consistency

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
   // latex-environment version: 0.5.0
-  // Compatible with texlive-ja-textlint: 2025d (TeXLive 2025)
+  // Compatible with texlive-ja-textlint: 2025e (TeXLive 2025)
   // See VERSIONS.md for compatibility matrix
   "name": "LaTeX Environment",
-  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025d",
+  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025e",
   
   "remoteUser": "texuser",
   

--- a/.textlintrc
+++ b/.textlintrc
@@ -1,22 +1,17 @@
 {
-    "plugins": [
-        "latex2e"
-    ],
-    "filters": {
-        "comments": true,
-        "allowlist": {
-            "allow": [
-                "/%[\\s\\S]*?$/m"
-            ]
-        }
-    },
     "rules": {
         "preset-ja-technical-writing": {
             "max-kanji-continuous-len": {
                 "max": 8,
                 "allow": [
                     "九州産業大学理工学部",
+                    "九州産業大学理工学部情報科学科",
+                    "九州産業大学理工学部情報科学科下川研究室",
                     "九州産業大学理工学部卒業論文",
+                    "九州産業大学大学院",
+                    "九州産業大学大学院情報科学研究科",
+                    "九州産業大学大学院情報科学研究科博士前期課程",
+                    "九州産業大学大学院情報科学研究科下川研究室",
                     "九州産業大学情報科学部",
                     "九州産業大学情報科学部卒業論文",
                     "福岡女子大学国際文理学部"
@@ -25,7 +20,9 @@
             "no-invalid-control-character": true,
             "no-unmatched-pair": true,
             "sentence-length": {
-                "max": 100
+                "max": 100,
+                "skipUrlStringLink": true,
+                "skipEmailLink": true
             },
             "no-nfd": true,
             "no-doubled-joshi": {
@@ -64,6 +61,60 @@
                 "preferInList": "である",
                 "strict": true
             }
+        },
+        "terminology": {
+            "defaultTerms": false,
+            "terms": [
+                "JavaScript",
+                "HTML",
+                "CSS",
+                "GitHub",
+                "LaTeX",
+                "VS Code"
+            ]
         }
-    }
+    },
+    "overrides": [
+        {
+            "files": ["*.html"],
+            "plugins": ["html"],
+            "filters": {
+                "comments": true,
+                "allowlist": {
+                    "allow": [
+                        "/<!--[\\s\\S]*?-->/m",
+                        "/<p class=\"author\"[\\s\\S]*?<\\/p>/",
+                        "/<div class=\"learning-progress\"[\\s\\S]*?<\\/div>/",
+                        "/<code[\\s\\S]*?<\\/code>/",
+                        "/<pre[\\s\\S]*?<\\/pre>/"
+                    ]
+                }
+            }
+        },
+        {
+            "files": ["*.md", "*.markdown"],
+            "filters": {
+                "allowlist": {
+                    "allow": [
+                        "/```[\\s\\S]*?```/m",
+                        "/`[^`]+`/g",
+                        "/\\[[^\\]]+\\]\\([^)]+\\)/g",
+                        "/!\\[[^\\]]*\\]\\([^)]+\\)/g"
+                    ]
+                }
+            }
+        },
+        {
+            "files": ["*.tex", "*.latex"],
+            "plugins": ["latex2e"],
+            "filters": {
+                "comments": true,
+                "allowlist": {
+                    "allow": [
+                        "/%[\\s\\S]*?$/m"
+                    ]
+                }
+            }
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
Update devcontainer to use texlive-ja-textlint:2025e release and implement unified textlint configuration, providing consistent textlint environment across the entire ecosystem.

## Changes
### Docker Image Update
- Update devcontainer.json to use 2025e image
- Maintains compatibility with terminology rule support

### Unified Textlint Configuration  
- Add terminology rule with standardized technical terms (JavaScript, HTML, CSS, GitHub, LaTeX, VS Code)
- Expand max-kanji-continuous-len allowlist with complete university/department names
- Add comprehensive overrides for HTML, Markdown, and LaTeX file types
- Enhance sentence-length rule with URL and email link skipping

## Benefits
- Centralized textlint environment configuration
- Automatic distribution to all templates via aldc
- Consistent text quality standards across ecosystem
- No need for individual template modifications
- Standardized technical terminology usage

## Technical Details
- **File Type Support**: HTML (with html plugin), Markdown (with link filtering), LaTeX (with latex2e plugin)
- **Enhanced Filtering**: Comments, code blocks, links properly excluded from linting
- **University Names**: Complete coverage of institutional names exceeding 8-character kanji limit
- **Modern Configuration**: Uses overrides pattern for file-type specific handling

## Test plan
- [x] 2025e image includes all required textlint rules including terminology
- [x] Unified .textlintrc configuration works with 2025e
- [x] Terminology rule detects and corrects technical term inconsistencies
- [x] File-type overrides work correctly for HTML, Markdown, LaTeX
- [x] aldc will distribute updated environment automatically