### PR TITLE
Fix GitHub Actions to remove test files from release branch

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -87,6 +87,13 @@ jobs:
           rm -f CLAUDE.md || true
           # Keep: README.md for template users
           
+          # Remove test files and development artifacts
+          rm -f main.tex || true
+          rm -f test*.md || true
+          rm -f test*.tex || true
+          rm -f .textlintrc-test || true
+          # Keep: .textlintrc for template users
+          
           # Validate version format
           if [[ ! "${{ steps.check.outputs.new_tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid version format: ${{ steps.check.outputs.new_tag }}"


### PR DESCRIPTION
## Summary

Fixes GitHub Actions workflow to properly clean up test files from the release branch.

## Problem

The release branch currently contains test files that should not be distributed to template users:
- `main.tex` (development test file)
- `test*.md` files (textlint testing artifacts)
- `.textlintrc-test` (temporary test configuration)

## Solution

Enhanced the `create-release.yml` workflow to remove test files and development artifacts from the release branch:

```yaml
# Remove test files and development artifacts
rm -f main.tex || true
rm -f test*.md || true
rm -f test*.tex || true
rm -f .textlintrc-test || true
# Keep: .textlintrc for template users
```

## Manual Cleanup

Also manually cleaned up the current release branch by removing existing test files.

## Impact

- **Release branch**: Now clean for template users
- **Main branch**: Test files remain for development use
- **Future releases**: Will automatically exclude test files

## Related

- Addresses the issue where test files were incorrectly included in user templates
- Ensures aldc distributes clean template environment