### PR TITLE
Remove .claude/settings.local.json from repository tracking

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(find:*)",
-      "Bash(ls:*)"
-    ],
-    "deny": []
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,6 @@ tags
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
+
+# Claude Code local settings
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Remove `.claude/settings.local.json` from git tracking and add to .gitignore to prevent future tracking.

## Changes
- **Remove from git**: Stop tracking `.claude/settings.local.json`
- **.gitignore update**: Add `.claude/settings.local.json` to prevent future commits
- **Local file preserved**: Keep local file for development purposes

## Rationale
- Local settings should not be shared in template repositories
- Users should configure Claude Code permissions individually
- Prevents accidental commit of personal development settings

## Technical Details
- Used `git rm --cached` to remove from tracking without deleting local file
- Added specific ignore pattern for Claude Code local settings
- Template users will need to configure their own `.claude/settings.local.json` if needed

## Previous Settings
The removed file contained:
```json
{
  "permissions": {
    "allow": [
      "Bash(find:*)",
      "Bash(ls:*)"
    ],
    "deny": []
  }
}
```

These permissions should be configured individually by developers as needed.