### PR TITLE
Fix check-texlive-updates workflow to handle local branches

### DIFF
--- a/.github/workflows/check-texlive-updates.yml
+++ b/.github/workflows/check-texlive-updates.yml
@@ -186,8 +186,12 @@ jobs:
           # Use version-based branch name (no timestamp to prevent duplicates)
           BRANCH_NAME="update-texlive-${CLEAN_TAG}"
 
-          # Check if branch or PR already exists for this version with enhanced validation
-          EXISTING_BRANCH=$(git ls-remote --heads origin "$BRANCH_NAME" | head -1)
+          # Fetch latest remote branches to ensure accurate checking
+          git fetch origin --prune
+
+          # Check if branch exists locally or remotely
+          LOCAL_BRANCH=$(git branch --list "$BRANCH_NAME" | head -1)
+          REMOTE_BRANCH=$(git ls-remote --heads origin "$BRANCH_NAME" | head -1)
 
           # Secure PR search with error handling
           EXISTING_PR=""
@@ -205,13 +209,20 @@ jobs:
             echo "Warning: PR search failed, continuing with branch check only"
           fi
 
-          if [ -n "$EXISTING_BRANCH" ] || [ -n "$EXISTING_PR" ]; then
+          if [ -n "$LOCAL_BRANCH" ] || [ -n "$REMOTE_BRANCH" ] || [ -n "$EXISTING_PR" ]; then
             echo "Update already in progress:"
-            [ -n "$EXISTING_BRANCH" ] && echo "  - Branch exists: $BRANCH_NAME"
+            [ -n "$LOCAL_BRANCH" ] && echo "  - Local branch exists: $BRANCH_NAME"
+            [ -n "$REMOTE_BRANCH" ] && echo "  - Remote branch exists: $BRANCH_NAME"
             [ -n "$EXISTING_PR" ] && echo "  - PR exists: #$EXISTING_PR"
             echo "Skipping duplicate update."
             echo "update_needed=false" >> $GITHUB_OUTPUT
             exit 0
+          fi
+
+          # Clean up any existing local branch before creating new one
+          if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+            echo "Cleaning up existing local branch: $BRANCH_NAME"
+            git branch -D "$BRANCH_NAME"
           fi
 
           git checkout -b "$BRANCH_NAME"


### PR DESCRIPTION
## Summary
- Fix workflow failure when local update branches exist
- Add comprehensive branch detection (both local and remote)
- Implement automatic cleanup of conflicting local branches

## Problem
The check-texlive-updates workflow was failing with exit code 1 when trying to create update branches that already existed locally. This happened because the workflow only checked for remote branches, not local ones.

See failed workflow run: https://github.com/smkwlab/latex-environment/actions/runs/15767611023

## Solution
1. **Enhanced branch detection**: Now checks both local and remote branches
2. **Automatic cleanup**: Removes existing local branches before creating new ones
3. **Improved logging**: Clearly distinguishes between local and remote branch conflicts

## Changes
- Added \`git fetch origin --prune\` to ensure accurate remote state
- Added local branch detection using \`git branch --list\`
- Added automatic cleanup of existing local branches
- Improved error messages to show whether conflicts are local or remote

## Testing
- The workflow will now handle cases where update branches were created manually
- Prevents duplicate branch creation errors that were causing workflow failures