### PR TITLE
Fix JSONC comment handling in create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,13 +39,21 @@ jobs:
               exit 1
             fi
 
-            if ! jq empty .devcontainer/devcontainer.json 2>/dev/null; then
-              echo "Error: Invalid JSON format in devcontainer.json"
+            # Remove JSONC comments for jq processing
+            TEMP_JSON=$(mktemp)
+            trap 'rm -f "$TEMP_JSON"' EXIT
+            
+            # Strip comments and validate JSON
+            if ! sed 's|//.*||g' .devcontainer/devcontainer.json | jq empty 2>/dev/null; then
+              echo "Error: Invalid JSON format in devcontainer.json (after comment removal)"
               exit 1
             fi
+            
+            # Create clean JSON for processing
+            sed 's|//.*||g' .devcontainer/devcontainer.json > "$TEMP_JSON"
 
             # Get the actual texlive version using secure parsing
-            NEW_VERSION=$(jq -r '.image // empty' .devcontainer/devcontainer.json | \
+            NEW_VERSION=$(jq -r '.image // empty' "$TEMP_JSON" | \
               sed -n 's/.*texlive-ja-textlint://p')
 
             # Validate extracted version


### PR DESCRIPTION
## Problem
create-release workflowがdevcontainer.jsonのJSONコメントに対応しておらず、実行が失敗していました。

```
Error: Invalid JSON format in devcontainer.json
```

## Root Cause
devcontainer.jsonはJSONC形式（JSONコメント付き）で記述されているが、ワークフローではjqでの標準JSON検証を実行していたため。

## Solution
- JSONCコメントを除去してからjq検証を実行
- 一時ファイルでクリーンなJSONを作成
- 既存のdevcontainer.json形式を維持

## Changes
```diff
- if \! jq empty .devcontainer/devcontainer.json 2>/dev/null; then
+ # Remove JSONC comments for jq processing
+ TEMP_JSON=$(mktemp)
+ trap 'rm -f "$TEMP_JSON"' EXIT
+ 
+ # Strip comments and validate JSON
+ if \! sed 's|//.*||g' .devcontainer/devcontainer.json | jq empty 2>/dev/null; then
+   echo "Error: Invalid JSON format in devcontainer.json (after comment removal)"
+   exit 1
+ fi
+ 
+ # Create clean JSON for processing  
+ sed 's|//.*||g' .devcontainer/devcontainer.json > "$TEMP_JSON"
```

## Benefits
- JSONC形式のdevcontainer.jsonをサポート
- ワークフローの自動実行を修復
- 開発者向けの可読性（コメント）を維持

## Test
- [x] ローカルでのJSONC処理テスト
- [ ] CI/CDでの動作確認