### PR TITLE
Fix check-texlive-updates workflow: handle JSONC comments and remove redundant validation

### DIFF
--- a/.github/workflows/check-texlive-updates.yml
+++ b/.github/workflows/check-texlive-updates.yml
@@ -80,20 +80,15 @@ jobs:
           echo "Latest texlive-ja-textlint tag: $LATEST_TAG"
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
 
-          # Get current version from devcontainer.json using secure parsing
+          # Get current version from devcontainer.json
           if [ ! -f ".devcontainer/devcontainer.json" ]; then
             echo "Error: devcontainer.json not found"
             exit 1
           fi
 
-          # Validate JSON format first
-          if ! jq empty .devcontainer/devcontainer.json 2>/dev/null; then
-            echo "Error: Invalid JSON format in devcontainer.json"
-            exit 1
-          fi
-
-          # Extract version using jq for safer parsing
-          CURRENT_VERSION=$(jq -r '.image // empty' .devcontainer/devcontainer.json | \
+          # Extract version directly (handles JSONC comments)
+          CURRENT_VERSION=$(sed -e 's|//.*||g' .devcontainer/devcontainer.json | \
+            jq -r '.image // empty' 2>/dev/null | \
             sed -n 's/.*texlive-ja-textlint://p' | head -1)
 
           # Validate extracted version


### PR DESCRIPTION
## Summary

Fixes the `check-texlive-updates` workflow that has been failing due to JSON comments in `devcontainer.json`.

## Changes

### 1. Handle JSONC Comments
- Add `sed -e 's|//.*||g'` to strip JSON comments before `jq` processing
- This allows the workflow to handle VSCode's JSONC format properly

### 2. Remove Redundant JSON Validation
- Remove the separate `jq empty` validation step
- Combine validation with version extraction in a single `jq` execution
- Better performance and simpler code

### Before
```yaml
# Validate JSON format first
if \! jq empty .devcontainer/devcontainer.json 2>/dev/null; then
  echo "Error: Invalid JSON format in devcontainer.json"
  exit 1
fi

# Extract version using jq for safer parsing
CURRENT_VERSION=$(jq -r '.image // empty' .devcontainer/devcontainer.json | \
  sed -n 's/.*texlive-ja-textlint://p' | head -1)
```

### After
```yaml
# Extract version directly (handles JSONC comments)
CURRENT_VERSION=$(sed -e 's|//.*||g' .devcontainer/devcontainer.json | \
  jq -r '.image // empty' 2>/dev/null | \
  sed -n 's/.*texlive-ja-textlint://p' | head -1)
```

## Resolves

- Fixes https://github.com/smkwlab/latex-environment/issues/104
- Fixes daily workflow failures since 2025-06-27
- Failed runs: https://github.com/smkwlab/latex-environment/actions/runs/15985472035

## Test Plan

- [x] Manual workflow dispatch to verify fix works
- [ ] Scheduled run verification after merge

## Notes

This approach is consistent with `create-release.yml` which already handles JSONC comments properly.