### PR TITLE
Fix LaTeX output directory setting in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
             ]
         }
     ],
+    "latex-workshop.latex.outDir": "",
     "latex-workshop.latex.autoBuild.run": "onSave",
     "latex-workshop.latex.watch.delay": 1000,
     "latex-workshop.synctex.afterBuild.enabled": true,


### PR DESCRIPTION
## 概要
LaTeX Workshop の出力ディレクトリ設定を修正しました。

## 変更内容
`.vscode/settings.json` に以下の設定を追加：
```json
"latex-workshop.latex.outDir": ""
```

## 理由
この設定により、PDFなどの出力ファイルが `.tex` ファイルと同じディレクトリに生成されるようになります。これは標準的なLaTeXワークフローに準拠した動作です。

## 影響
- PDFファイルが `.tex` ファイルと同じ場所に生成される
- ファイル管理がシンプルになる
- 他のLaTeX環境との互換性が向上する