### PR TITLE
Update texlive-ja-textlint to 2025h

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
-  // Compatible with texlive-ja-textlint: 2025e (TeXLive 2025)
+  // Compatible with texlive-ja-textlint: 2025h (TeXLive 2025)
   "name": "LaTeX Environment",
-  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025e",
+  "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025h",
   
   "remoteUser": "texuser",
   

--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -19,5 +19,5 @@ jobs:
       - name: Build LaTeX with Docker
         run: |
           docker run --rm -v $(pwd):/workspace -w /workspace \
-            ghcr.io/smkwlab/texlive-ja-textlint:2025e \
+            ghcr.io/smkwlab/texlive-ja-textlint:2025h \
             latexmk -pdf main.tex || echo "No main.tex found, skipping build"


### PR DESCRIPTION
## Summary

Update Docker image from `texlive-ja-textlint:2025e` to `2025h` to incorporate the latest textlint upgrade.

## Changes

- Update `.devcontainer/devcontainer.json` to use `2025h` image
- Update `.github/workflows/latex-build.yml` to use `2025h` image

## Key Updates in 2025h

- textlint upgraded from v13.0.2 to v14.8.4
- Synchronized package.json and package-lock.json

## Impact

This update will propagate to all templates that use `latex-environment`:
- sotsuron-template
- wr-template
- latex-template
- ise-report-template
- poster-template

## Related

- texlive-ja-textlint tag: https://github.com/smkwlab/texlive-ja-textlint/releases/tag/2025h
- Previous discussion in texlive-ja-textlint#42, #43