### PR TITLE
Fix remoteUser setting in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "name": "LaTeX Environment",
   "image": "ghcr.io/smkwlab/texlive-ja-textlint:2025h",
   
-  "remoteUser": "texuser",
+  "remoteUser": "root",
   
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## 概要
VS Code Dev Container起動時のユーザーエラーを修正します。

## 変更内容
`.devcontainer/devcontainer.json`の`remoteUser`を`"texuser"`から`"root"`に変更

## 問題
Dockerイメージ`ghcr.io/smkwlab/texlive-ja-textlint:2025h`には`texuser`ユーザーが存在せず、以下のエラーが発生していました：
```
Unable To Find User Texuser: No Matching Entries In Passwd File
```

## 影響範囲
- latex-environmentテンプレートから作成されたすべてのリポジトリ
- setup.shで作成された学生リポジトリ（例: k19rs999-sotsuron）

## 解決方法
Dockerイメージの実際のユーザー（`root`）に合わせて設定を修正

Resolve #120