### PR TITLE
Add pre-commit hook setup for review workflow repositories

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,6 +48,6 @@
   "postCreateCommand": [
     "bash",
     "-c",
-    "echo '🎉 LaTeX環境が準備できました！'; echo ''; echo '📝 LaTeX文書のコンパイルを開始するには:'; echo '  - Ctrl+Shift+P (macOS: Cmd+Shift+P)'; echo '  - \"LaTeX Workshop: Build LaTeX project\" を選択'; echo '  - または sotsuron.tex (などの .tex ファイル) を開いて Ctrl+Alt+B (macOS: Cmd+Option+B)'; echo ''; echo '📖 詳細な使用方法は README.md を確認してください。'"
+    "bash .devcontainer/setup-git-hooks.sh && echo '🎉 LaTeX環境が準備できました！'; echo ''; echo '📝 LaTeX文書のコンパイルを開始するには:'; echo '  - Ctrl+Shift+P (macOS: Cmd+Shift+P)'; echo '  - \"LaTeX Workshop: Build LaTeX project\" を選択'; echo '  - または sotsuron.tex (などの .tex ファイル) を開いて Ctrl+Alt+B (macOS: Cmd+Option+B)'; echo ''; echo '📖 詳細な使用方法は README.md を確認してください。'"
   ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,6 +48,6 @@
   "postCreateCommand": [
     "bash",
     "-c",
-    "bash .devcontainer/setup-git-hooks.sh && echo '🎉 LaTeX環境が準備できました！'; echo ''; echo '📝 LaTeX文書のコンパイルを開始するには:'; echo '  - Ctrl+Shift+P (macOS: Cmd+Shift+P)'; echo '  - \"LaTeX Workshop: Build LaTeX project\" を選択'; echo '  - または sotsuron.tex (などの .tex ファイル) を開いて Ctrl+Alt+B (macOS: Cmd+Option+B)'; echo ''; echo '📖 詳細な使用方法は README.md を確認してください。'"
+    "bash .devcontainer/setup-git-hooks.sh || true && echo '🎉 LaTeX環境が準備できました！'; echo ''; echo '📝 LaTeX文書のコンパイルを開始するには:'; echo '  - Ctrl+Shift+P (macOS: Cmd+Shift+P)'; echo '  - \"LaTeX Workshop: Build LaTeX project\" を選択'; echo '  - または sotsuron.tex (などの .tex ファイル) を開いて Ctrl+Alt+B (macOS: Cmd+Option+B)'; echo ''; echo '📖 詳細な使用方法は README.md を確認してください。'"
   ]
 }

--- a/.devcontainer/setup-git-hooks.sh
+++ b/.devcontainer/setup-git-hooks.sh
@@ -19,8 +19,7 @@ if [ "$BRANCH" = "main" ]; then
     echo "⚠️  警告: main ブランチにコミットしようとしています！"
     echo "=========================================="
     echo ""
-    echo "ドラフトブランチに切り替えてください:"
-    echo "  git checkout 0th-draft"
+    echo "ドラフトブランチ (xth-draft) に切り替えてください:"
     echo ""
     echo "コミットを中断しました。"
     exit 1

--- a/.devcontainer/setup-git-hooks.sh
+++ b/.devcontainer/setup-git-hooks.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e  # Exit on error
 # Setup git hooks for review workflow repositories
 # This script is automatically executed during DevContainer creation
 
@@ -9,10 +10,18 @@ fi
 
 echo "レビューワークフロー用リポジトリの pre-commit hook を設定中..."
 
+# Ensure .git/hooks directory exists
+if [ ! -d ".git/hooks" ]; then
+    mkdir -p .git/hooks
+fi
+
 cat > .git/hooks/pre-commit << 'EOF'
 #!/bin/bash
 
-BRANCH=$(git symbolic-ref --short HEAD)
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ -z "$BRANCH" ]; then
+    exit 0
+fi
 
 if [ "$BRANCH" = "main" ]; then
     echo "=========================================="

--- a/.devcontainer/setup-git-hooks.sh
+++ b/.devcontainer/setup-git-hooks.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Setup git hooks for review workflow repositories
+# This script is automatically executed during DevContainer creation
+
+# Check if this is a review workflow repository
+if [ ! -f ".devcontainer/.review-workflow" ]; then
+    exit 0
+fi
+
+echo "レビューワークフロー用リポジトリの pre-commit hook を設定中..."
+
+cat > .git/hooks/pre-commit << 'EOF'
+#!/bin/bash
+
+BRANCH=$(git symbolic-ref --short HEAD)
+
+if [ "$BRANCH" = "main" ]; then
+    echo "=========================================="
+    echo "⚠️  警告: main ブランチにコミットしようとしています！"
+    echo "=========================================="
+    echo ""
+    echo "ドラフトブランチに切り替えてください:"
+    echo "  git checkout 0th-draft"
+    echo ""
+    echo "コミットを中断しました。"
+    exit 1
+fi
+EOF
+
+chmod +x .git/hooks/pre-commit
+echo "✅ Git pre-commit hook を設定しました"


### PR DESCRIPTION
## Summary

DevContainer 起動時に自動的に pre-commit hook を設定する機能を追加しました。レビューワークフロー用リポジトリ（sotsuron-template、ise-report-template）において、学生が誤って main ブランチにコミットすることを防ぎます。

## Changes

### 新規ファイル

- **\`.devcontainer/setup-git-hooks.sh\`**: Git hooks 設定スクリプト
  - \`.devcontainer/.review-workflow\` マーカーファイルが存在する場合のみ動作
  - pre-commit hook を自動生成・設置
  - main ブランチへのコミットを検知して中断

### 変更ファイル

- **\`.devcontainer/devcontainer.json\`**: postCreateCommand に hook 設定スクリプトを追加

## Behavior

### レビューワークフロー用リポジトリの場合

1. DevContainer 起動時に \`.devcontainer/.review-workflow\` を確認
2. 存在すれば pre-commit hook を設定
3. 学生が main ブランチでコミットしようとすると:
   ```
   ==========================================
   ⚠️  警告: main ブランチにコミットしようとしています！
   ==========================================
   
   ドラフトブランチに切り替えてください:
     git checkout 0th-draft
   
   コミットを中断しました。
   ```

### 通常リポジトリの場合

- マーカーファイルが存在しないため、何も実行されない（サイレント）

## Benefits

- 学生が誤って main にコミットすることを事前に防止
- push 時のエラーではなく、commit 時点で防止（より早期の警告）
- 日本語メッセージで学生に分かりやすく指示
- マーカーファイル方式で柔軟な制御が可能

## Testing

sotsuron-template と ise-report-template に \`.devcontainer/.review-workflow\` を追加することで動作確認可能です。