### PR TITLE
Add Renovate configuration for dependency management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "dependencyDashboardLabels": ["dependencies"],
+  "extends": ["config:base", "workarounds:all"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["after 9pm on sunday"],
+  "semanticCommits": "enabled",
+  "packageRules": [
+    {
+      "description": "GitHub Actions version updates",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
+      "labels": ["dependencies", "github-actions"],
+      "semanticCommitType": "ci"
+    },
+    {
+      "description": "Docker base image updates",
+      "matchManagers": ["dockerfile"],
+      "pinDigests": true,
+      "labels": ["dependencies", "docker"],
+      "semanticCommitType": "build"
+    },
+    {
+      "description": "npm dependency updates",
+      "matchManagers": ["npm"],
+      "labels": ["dependencies", "npm"],
+      "rangeStrategy": "bump",
+      "semanticCommitType": "chore"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Renovate bot による依存関係の自動更新管理を導入します。

## Config
- 対象: GitHub Actions, Docker base images, npm
- スケジュール: 週1回（日曜 21:00 JST）
- automerge: 無効（手動レビュー必須）
- ラベル・semantic commit type をカテゴリ別に分類

## Next steps
PR マージ後、Renovate GitHub App の選択リポジトリにこのリポジトリを追加する必要があります。