### PR TITLE
Default to uplatex and unify .latexmkrc options

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,7 +1,7 @@
-$latex = 'platex -synctex=1 -file-line-error -interaction=nonstopmode';
-$bibtex = 'pbibtex';
-#$latex = 'uplatex -synctex=1 -file-line-error -interaction=nonstopmode';
-#$bibtex = 'upbibtex';
+$latex = 'uplatex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
+$bibtex = 'upbibtex';
+#$latex = 'platex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
+#$bibtex = 'pbibtex';
 $dvipdf = 'dvipdfmx %O -o %D %S';
-$makeindex = 'mendex -U %O -o %D %S';
-$pdf_mode = 3; 
+$makeindex = 'upmendex %O -o %D %S';
+$pdf_mode = 3;


### PR DESCRIPTION
## 概要

エコシステム全体の `.latexmkrc` 統一の一環です。基盤環境テンプレートのデフォルトエンジンを **uplatex** に揃えます。

## 変更内容

| 項目 | Before | After |
|---|---|---|
| デフォルトエンジン | `platex`（uplatex はコメントアウト） | **`uplatex`**（platex をコメントアウトで残置） |
| bibtex | `pbibtex` | `upbibtex` |
| makeindex | `mendex -U` | **`upmendex`**（uplatex の Unicode 内部表現に適合） |
| オプション | `-synctex=1 -file-line-error -interaction=nonstopmode` | `-synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode` |

```perl
$latex = 'uplatex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
$bibtex = 'upbibtex';
#$latex = 'platex -synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode';
#$bibtex = 'pbibtex';
$dvipdf = 'dvipdfmx %O -o %D %S';
$makeindex = 'upmendex %O -o %D %S';
$pdf_mode = 3;
```

## 補足

- エコシステムの他テンプレート（sotsuron-template / sotsuron-report-template / wr-template）はすべて uplatex で統一されており、基盤環境のデフォルトもこれに合わせます。
- platex を使いたい場合はコメントアウト行を切り替えるだけで利用可能です。
- `release` ブランチ（学生が利用）への反映は別途必要です。
- `-interaction=nonstopmode` の CI 側との二重指定回避は共有ワークフロー `smkwlab/.github` の改修が必要なため、別途対応します。