### PR TITLE
Update developer docs to reflect uplatex-default .latexmkrc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ textlint --fix *.tex          # Auto-fix issues where possible
 ```
 
 ### Development Environment
-- **TeXLive 2025** with full Japanese support (platex/uplatex)
+- **TeXLive 2025** with full Japanese support (uplatex/platex)
 - **textlint** for Japanese academic writing style checking
 - **VSCode devcontainer** with LaTeX Workshop and TeXLab
 - **Base image**: `ghcr.io/smkwlab/texlive-ja-textlint:2025b`

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -15,7 +15,11 @@ The repository uses a Docker-based development container that automatically sets
 ### Build System
 - **latexmk**: Automated LaTeX compilation with dependency tracking
 - **Configuration**: `.latexmkrc` defines the build process:
-  - Default engines: `$latex=uplatex`, `$bibtex=upbibtex`, `$makeindex=upmendex`, `$dvipdf=dvipdfmx`, `$pdf_mode=3` (DVI → PDF)
+  - Default toolchain (`$pdf_mode=3`, i.e. DVI → PDF): `$latex` uses uplatex,
+    `$bibtex` uses upbibtex, `$makeindex` uses upmendex, `$dvipdf` uses dvipdfmx.
+    Each variable holds the full command string with options (e.g. `$latex` adds
+    `-synctex=1 -halt-on-error -file-line-error -interaction=nonstopmode`; `$dvipdf`
+    and `$makeindex` include `%O -o %D %S`) — see `.latexmkrc` for the exact strings.
   - Alternative: platex toolchain (commented out in config)
   - `.latexmkrc` only configures the engine commands; latexmk reruns each step as
     needed until cross-references, the index, and the bibliography are resolved

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -6,7 +6,7 @@ This document provides detailed development guidance for latex-environment.
 
 ### Development Environment
 The repository uses a Docker-based development container that automatically sets up:
-- **TeXLive 2025** with full Japanese support (platex/uplatex)
+- **TeXLive 2025** with full Japanese support (uplatex/platex)
 - **textlint** for Japanese academic writing style checking
 - **TeXLab** for advanced LaTeX language support and real-time syntax checking
 - **VSCode extensions**: LaTeX Workshop, TeXLab, GitHub Pull Requests, textlint
@@ -15,8 +15,8 @@ The repository uses a Docker-based development container that automatically sets
 ### Build System
 - **latexmk**: Automated LaTeX compilation with dependency tracking
 - **Configuration**: `.latexmkrc` defines the build process:
-  - Default: platex → pbibtex → platex (×3) → dvipdfmx
-  - Alternative: uplatex toolchain (commented out in config)
+  - Default: uplatex → upbibtex → uplatex (×3) → dvipdfmx (index via upmendex)
+  - Alternative: platex toolchain (commented out in config)
 - **SyncTeX**: Bidirectional navigation between .tex source and PDF output
 
 ### CI/CD Workflow

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -15,8 +15,10 @@ The repository uses a Docker-based development container that automatically sets
 ### Build System
 - **latexmk**: Automated LaTeX compilation with dependency tracking
 - **Configuration**: `.latexmkrc` defines the build process:
-  - Default: uplatex → upbibtex → uplatex (×3) → dvipdfmx (index via upmendex)
+  - Default engines: `$latex=uplatex`, `$bibtex=upbibtex`, `$makeindex=upmendex`, `$dvipdf=dvipdfmx`, `$pdf_mode=3` (DVI → PDF)
   - Alternative: platex toolchain (commented out in config)
+  - `.latexmkrc` only configures the engine commands; latexmk reruns each step as
+    needed until cross-references, the index, and the bibliography are resolved
 - **SyncTeX**: Bidirectional navigation between .tex source and PDF output
 
 ### CI/CD Workflow

--- a/docs/CLAUDE-TROUBLESHOOTING.md
+++ b/docs/CLAUDE-TROUBLESHOOTING.md
@@ -24,7 +24,7 @@ This document provides troubleshooting information for common issues in latex-en
 ### Container Environment
 ```bash
 # Check container environment
-docker run --rm ghcr.io/smkwlab/texlive-ja-textlint:2025b platex --version
+docker run --rm ghcr.io/smkwlab/texlive-ja-textlint:2025b uplatex --version
 
 # Test LaTeX installation
 docker run --rm ghcr.io/smkwlab/texlive-ja-textlint:2025b kpsewhich article.cls


### PR DESCRIPTION
## 概要

PR #138 で `.latexmkrc` のデフォルトエンジンを platex → **uplatex** に変更（platex はコメントアウトで残置）した一方、開発者向けドキュメントの一部が旧デフォルト（platex）前提のまま残っていました。これを実設定に整合させます。

resolve #139

## 変更内容

### `docs/CLAUDE-DEVELOPMENT.md`（必須）
Build System の Default/Alternative が逆だった点を修正:

```diff
-  - Default: platex → pbibtex → platex (×3) → dvipdfmx
-  - Alternative: uplatex toolchain (commented out in config)
+  - Default: uplatex → upbibtex → uplatex (×3) → dvipdfmx (index via upmendex)
+  - Alternative: platex toolchain (commented out in config)
```

### `docs/CLAUDE-TROUBLESHOOTING.md`
デバッグ例のエンジン確認を `platex --version` → `uplatex --version` に変更。

### 併記順序（`CLAUDE.md` / `docs/CLAUDE-DEVELOPMENT.md`）
`(platex/uplatex)` → `(uplatex/platex)` とデフォルト優先の表記に統一。

## 補足

- ドキュメントのみの変更で、コード・設定（`.latexmkrc` 等）の変更はありません。
- 対象ファイルは release ブランチからは除去される管理ファイルですが、開発者（Claude を含む）が参照するため整備しています。