### PR TITLE
Add YAML/Actions workflow validation (yamllint + actionlint)

### DIFF
--- a/.github/workflows/ai-reviewer.yml
+++ b/.github/workflows/ai-reviewer.yml
@@ -1,3 +1,4 @@
+---
 name: "Academic Paper Review"
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+---
+# Lint Workflows
+#
+# Validates GitHub Actions workflow files using yamllint and actionlint
+# to catch YAML syntax errors and workflow mistakes before they cause
+# failed runs. Mirrors the smkwlab/.github org-standard lint workflow,
+# adding yamllint because this repository ships a .yamllint.yml config.
+
+name: Lint Workflows
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**', '.yamllint.yml']
+  pull_request:
+    branches: [main]
+    paths: ['.github/workflows/**', '.yamllint.yml']
+
+permissions:
+  contents: read
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v4
+
+      - name: Run yamllint
+        run: yamllint -c .yamllint.yml .github/workflows/
+
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Set up Git repository
         uses: actions/checkout@v4
 
+      - name: Install yamllint
+        run: pipx install yamllint==1.35.1
+
       - name: Run yamllint
         run: yamllint -c .yamllint.yml .github/workflows/
 

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -6,6 +6,7 @@ env:
   NON_LATEX_ENVIRONMENT_FILES: |
     .github/workflows/check-texlive-updates.yml
     .github/workflows/update-release-branch.yml
+    .github/workflows/lint.yml
     .github/BRANCH_NAMING.md
     .claude/
     DEPENDENCY-UPDATE.md
@@ -21,6 +22,7 @@ on:
     paths-ignore:
       - '.github/workflows/check-texlive-updates.yml'
       - '.github/workflows/update-release-branch.yml'
+      - '.github/workflows/lint.yml'
       - '.github/BRANCH_NAMING.md'
       - '.claude/**'
       - 'DEPENDENCY-UPDATE.md'
@@ -157,7 +159,8 @@ jobs:
 
           git add -A
           if [[ "${{ steps.check.outputs.update_type }}" == "texlive" ]]; then
-            git commit -m "Update release branch for texlive-ja-textlint ${{ steps.check.outputs.texlive_version }}" || true
+            texlive_version="${{ steps.check.outputs.texlive_version }}"
+            git commit -m "Update release branch for texlive-ja-textlint ${texlive_version}" || true
           else
             git commit -m "Update release branch for environment changes" || true
           fi

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -32,6 +32,17 @@ The repository uses a Docker-based development container that automatically sets
 - **Action**: Uses `smkwlab/latex-release-action@v2.2.0`
 - **Default target**: `main.tex` (configurable via `tex_file` input)
 
+### Workflow File Validation
+GitHub Actions YAML files are validated automatically to catch syntax
+errors before they cause failed runs:
+- **Workflow**: `.github/workflows/lint.yml`
+- **Triggers**: Pushes and PRs touching `.github/workflows/**` or `.yamllint.yml`
+- **Tools**:
+  - **yamllint** — YAML syntax and formatting (config in `.yamllint.yml`)
+  - **actionlint** — GitHub Actions schema, expressions, and `run:` shell checks
+- This mirrors the `smkwlab/.github` org-standard lint workflow, adding
+  yamllint because this repository ships a `.yamllint.yml` config.
+
 ### Version Management System
 - **VERSION file**: Tracks current version in release branch
 - **VERSIONS.md**: Compatibility matrix with texlive-ja-textlint
@@ -118,6 +129,25 @@ latexmk -c
 # Test textlint
 textlint *.tex
 ```
+
+### Validating Workflow Files Locally
+Run the same checks CI performs before pushing workflow changes:
+```bash
+# Install tools (macOS)
+brew install yamllint actionlint
+
+# Install tools (Ubuntu/Debian: yamllint via apt, actionlint via release binary)
+sudo apt-get install -y yamllint
+
+# YAML syntax and formatting (uses .yamllint.yml)
+yamllint -c .yamllint.yml .github/workflows/
+
+# GitHub Actions schema, expressions, and shell checks
+actionlint
+```
+Both commands should exit cleanly with no output. Fix any reported
+issues before committing — the `Lint Workflows` CI job runs these same
+checks on pull requests.
 
 ### Integration Testing
 - Test with both platex and uplatex workflows

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -136,8 +136,13 @@ Run the same checks CI performs before pushing workflow changes:
 # Install tools (macOS)
 brew install yamllint actionlint
 
-# Install tools (Ubuntu/Debian: yamllint via apt, actionlint via release binary)
+# Install tools (Ubuntu/Debian)
+#   yamllint: from apt (or `pipx install yamllint`)
 sudo apt-get install -y yamllint
+#   actionlint: download the latest release binary into the current dir
+#   (see https://github.com/rhysd/actionlint/blob/main/docs/install.md)
+bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+#   then run it as ./actionlint (or move it onto your PATH)
 
 # YAML syntax and formatting (uses .yamllint.yml)
 yamllint -c .yamllint.yml .github/workflows/

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -139,10 +139,12 @@ brew install yamllint actionlint
 # Install tools (Ubuntu/Debian)
 #   yamllint: from apt (or `pipx install yamllint`)
 sudo apt-get install -y yamllint
-#   actionlint: download the latest release binary into the current dir
-#   (see https://github.com/rhysd/actionlint/blob/main/docs/install.md)
-bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-#   then run it as ./actionlint (or move it onto your PATH)
+#   actionlint: download a pinned release binary, then put it on PATH so
+#   the `actionlint` command below resolves (version matches CI's
+#   rhysd/actionlint@v1.7.7). See
+#   https://github.com/rhysd/actionlint/blob/main/docs/install.md
+bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+sudo install actionlint /usr/local/bin/
 
 # YAML syntax and formatting (uses .yamllint.yml)
 yamllint -c .yamllint.yml .github/workflows/

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -139,12 +139,13 @@ brew install yamllint actionlint
 # Install tools (Ubuntu/Debian)
 #   yamllint: from apt (or `pipx install yamllint`)
 sudo apt-get install -y yamllint
-#   actionlint: download a pinned release binary, then put it on PATH so
-#   the `actionlint` command below resolves (version matches CI's
-#   rhysd/actionlint@v1.7.7). See
+#   actionlint: download the pinned install script to a file, review it,
+#   then run it (avoids piping unreviewed remote code straight into bash).
+#   Version matches CI's rhysd/actionlint@v1.7.7. See
 #   https://github.com/rhysd/actionlint/blob/main/docs/install.md
-bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
-sudo install actionlint /usr/local/bin/
+curl -sSfO https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash
+bash download-actionlint.bash 1.7.7        # downloads ./actionlint
+sudo install actionlint /usr/local/bin/    # put it on PATH
 
 # YAML syntax and formatting (uses .yamllint.yml)
 yamllint -c .yamllint.yml .github/workflows/


### PR DESCRIPTION
## Summary

Adds CI validation for GitHub Actions workflow files so YAML syntax errors are caught before they cause failed runs, fixes the existing yamllint violations in the repository, and documents the validation process.

Implements Issue #61 with the scope agreed for this repository: CI validation + fixing existing violations + documentation. **pre-commit hooks are intentionally not added**, following ecosystem convention — the reference implementation (`latex-template`) and other repositories do not use the pre-commit framework, and the org-standard shared workflow (`smkwlab/.github` `lint.yml`) runs lint checks in CI only. Avoiding a pre-commit dependency keeps friction low for this student-facing template.

## Changes

- **Add `.github/workflows/lint.yml`** — runs `yamllint` and `actionlint` on pushes/PRs touching `.github/workflows/**` or `.yamllint.yml`. Mirrors the `smkwlab/.github` org-standard lint workflow, adding yamllint because this repo ships a `.yamllint.yml` config.
- **Fix existing yamllint violations** (the repo did not previously pass its own `.yamllint.yml`):
  - `ai-reviewer.yml`: add document-start marker `---`
  - `update-release-branch.yml`: shorten an over-length commit line (124 > 120) by extracting `texlive_version` into a shell variable
- **Exclude `lint.yml` from the release branch** — it is a maintenance-only workflow (added to both `NON_LATEX_ENVIRONMENT_FILES` and `paths-ignore` in `update-release-branch.yml`), consistent with `check-texlive-updates.yml` and `update-release-branch.yml`.
- **Document the process** in `docs/CLAUDE-DEVELOPMENT.md`: local `yamllint`/`actionlint` usage and the CI validation job.

## Verification

Both linters pass cleanly on all workflow files locally:

```
yamllint -c .yamllint.yml .github/workflows/   # CLEAN
actionlint                                      # CLEAN
```

resolve #61