### PR TITLE
Fix self-corrupting texlive update workflow

### DIFF
--- a/.github/workflows/check-texlive-updates.yml
+++ b/.github/workflows/check-texlive-updates.yml
@@ -174,25 +174,29 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_ENV"
 
-      - name: Update all texlive-ja-textlint references
+      - name: Update texlive-ja-textlint reference in devcontainer.json
         if: steps.check.outputs.update_needed == 'true'
         run: |
-          # Update the image version in devcontainer.json
-          sed -i 's|"image": "ghcr.io/smkwlab/texlive-ja-textlint:[^"]*"|\
-            "image": "ghcr.io/smkwlab/texlive-ja-textlint:${{ steps.check.outputs.latest_tag }}"|' \
-            .devcontainer/devcontainer.json
+          TAG="${{ steps.check.outputs.latest_tag }}"
+          TEXLIVE_YEAR="${TAG:0:4}"
+          IMAGE="ghcr.io/smkwlab/texlive-ja-textlint"
+          DC=".devcontainer/devcontainer.json"
 
-          # Update the container image in workflow files (now using docker run instead of container mode)
-          find .github/workflows \( -name "*.yml" -o -name "*.yaml" \) -print0 | \
-            xargs -0 sed -i 's|ghcr.io/smkwlab/texlive-ja-textlint:[^[:space:]]*|\
-            ghcr.io/smkwlab/texlive-ja-textlint:${{ steps.check.outputs.latest_tag }}|g'
+          # Update the image tag (single-line replacement; must not span lines,
+          # otherwise sed embeds a stray newline into devcontainer.json)
+          sed -i "s|\"image\": \"${IMAGE}:[^\"]*\"|\"image\": \"${IMAGE}:${TAG}\"|" "$DC"
 
-          # Commit the changes
-          git add .devcontainer/devcontainer.json .github/workflows/
-          git commit -m "Update texlive-ja-textlint to ${{ steps.check.outputs.latest_tag }}
+          # Keep the compatibility comment in sync with the image tag
+          COMMENT="// Compatible with texlive-ja-textlint: ${TAG} (TeXLive ${TEXLIVE_YEAR})"
+          sed -i "s|// Compatible with texlive-ja-textlint:.*|${COMMENT}|" "$DC"
 
-          - Update devcontainer.json image reference
-          - Update workflow container images for consistency"
+          # Commit the change. Only devcontainer.json is touched: no workflow in
+          # this repo pins the image, so rewriting .github/workflows would only
+          # corrupt this file's own sed scripts.
+          git add "$DC"
+          git commit -m "Update texlive-ja-textlint to ${TAG}
+
+          - Update devcontainer.json image reference and compatibility comment"
 
       - name: Push changes
         if: steps.check.outputs.update_needed == 'true'
@@ -210,8 +214,8 @@ jobs:
           \`${{ steps.check.outputs.current_version }}\` to \`${{ steps.check.outputs.latest_tag }}\`.
 
           ### Changes
-          - Updated `.devcontainer/devcontainer.json` to use the latest texlive-ja-textlint image
-          - Updated GitHub Actions workflow container images for consistency
+          - Updated `.devcontainer/devcontainer.json` image tag to the latest texlive-ja-textlint release
+          - Updated the compatibility comment to match
 
           ### Release Notes
           View [release notes](https://github.com/smkwlab/texlive-ja-textlint/releases/tag/

--- a/.github/workflows/check-texlive-updates.yml
+++ b/.github/workflows/check-texlive-updates.yml
@@ -194,9 +194,9 @@ jobs:
           # this repo pins the image, so rewriting .github/workflows would only
           # corrupt this file's own sed scripts.
           git add "$DC"
-          git commit -m "Update texlive-ja-textlint to ${TAG}
-
-          - Update devcontainer.json image reference and compatibility comment"
+          git commit \
+            -m "Update texlive-ja-textlint to ${TAG}" \
+            -m "Update devcontainer.json image reference and compatibility comment"
 
       - name: Push changes
         if: steps.check.outputs.update_needed == 'true'


### PR DESCRIPTION
## 概要

自動更新ワークフロー \`check-texlive-updates.yml\` の「Update all texlive-ja-textlint references」ステップにバグがあり、無効なPR (#146) を生成していたため修正します。

## 検出されたバグ

PR #146 の差分で判明した2点:

### 1. devcontainer.json への stray newline 混入
image 更新の sed が、バックスラッシュ行継続を含む置換文字列を使っていたため、置換結果に改行＋インデントが埋め込まれていました。

- `devcontainer.json` に余計な空行が挿入される
- 互換性コメント (\`// Compatible with texlive-ja-textlint: ...\`) は sed の対象外で旧バージョンのまま残る

### 2. ワークフローファイルの自己破壊（重大）
\`find .github/workflows ... sed\` ステップが、ワークフロー内に書かれた image 参照パターン文字列そのものを置換し、本ワークフロー自身の sed スクリプトを破壊していました。本リポジトリにはイメージを実際に pin するワークフローは存在しないため、このステップは**不要かつ破壊的**でした。

## 修正内容

- image タグと互換性コメントを、それぞれ**単一行の sed** で置換（改行混入を防止）
- 変更対象を \`devcontainer.json\` のみに限定（\`.github/workflows/\` への sed を削除）
- 全行を yamllint の 120 桁制限内に収める

## 検証

- ✅ `yamllint -c .yamllint.yml` / `actionlint` ともにローカルで PASS
- ✅ 修正後ステップのシェルロジックを実物の devcontainer.json で再現し、image・コメント両方が \`2026a (TeXLive 2026)\` にクリーンに更新されることを確認
- ✅ **冪等性**: check ステップの抽出ロジックが更新後の \`2026a\` を読み戻すため、再更新ループは発生しない

## マージ後の流れ

このPRマージ後、ワークフローを再実行 (\`workflow_dispatch\`) すれば、2025i → 2026a のクリーンな更新PRが自動生成されます。