### PR TITLE
Fix duplicate-skip path in texlive update workflow

### DIFF
--- a/.github/workflows/check-texlive-updates.yml
+++ b/.github/workflows/check-texlive-updates.yml
@@ -119,6 +119,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create update branch
+        id: branch
         if: steps.check.outputs.update_needed == 'true'
         run: |
           git config --global user.name 'github-actions[bot]'
@@ -160,7 +161,10 @@ jobs:
             [ -n "$REMOTE_BRANCH" ] && echo "  - Remote branch exists: $BRANCH_NAME"
             [ -n "$EXISTING_PR" ] && echo "  - PR exists: #$EXISTING_PR"
             echo "Skipping duplicate update."
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
+            # Signal downstream steps to skip. This step has its own id, so the
+            # following steps gate on steps.branch.outputs.skip — writing to
+            # steps.check.outputs here would be ignored (different step id).
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -175,7 +179,9 @@ jobs:
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Update texlive-ja-textlint reference in devcontainer.json
-        if: steps.check.outputs.update_needed == 'true'
+        if: >-
+          steps.check.outputs.update_needed == 'true' &&
+          steps.branch.outputs.skip != 'true'
         run: |
           TAG="${{ steps.check.outputs.latest_tag }}"
           TEXLIVE_YEAR="${TAG:0:4}"
@@ -199,13 +205,17 @@ jobs:
             -m "Update devcontainer.json image reference and compatibility comment"
 
       - name: Push changes
-        if: steps.check.outputs.update_needed == 'true'
+        if: >-
+          steps.check.outputs.update_needed == 'true' &&
+          steps.branch.outputs.skip != 'true'
         run: |
           # Force push in case branch somehow exists
           git push origin "${{ env.branch_name }}" --force
 
       - name: Create Pull Request
-        if: steps.check.outputs.update_needed == 'true'
+        if: >-
+          steps.check.outputs.update_needed == 'true' &&
+          steps.branch.outputs.skip != 'true'
         run: |
           PR_BODY=$(cat <<'EOF'
           ## Automated Dependency Update


### PR DESCRIPTION
## Problem

The daily `check-texlive-updates` workflow has been **failing every run since an update PR already exists** (e.g. PR #148 for `2026a`). 6/6, 6/7, 6/8 all failed at the `Push changes` step with exit 128.

### Root cause

The `Create update branch` step correctly detects an existing branch/PR and tries to short-circuit:

```sh
echo "Skipping duplicate update."
echo "update_needed=false" >> "$GITHUB_OUTPUT"
exit 0
```

But this step has **no `id`**, so writing `update_needed=false` to `GITHUB_OUTPUT` goes nowhere useful — the downstream steps gate on `steps.check.outputs.update_needed`, which is still `true`. As a result:

1. The step exits 0 **before** setting `env.branch_name` (and before `git checkout -b`).
2. `Update devcontainer.json` still runs and creates a commit on `main`.
3. `Push changes` runs `git push origin "" --force` (empty `env.branch_name`) → **exit 128**.

Net effect: a failing run and a failure-notification email **every single day** while an update PR is open.

## Fix

- Give the step `id: branch` and emit `skip=true` instead of the dead `update_needed=false` write.
- Gate the `Update devcontainer.json`, `Push changes`, and `Create Pull Request` steps on `steps.check.outputs.update_needed == 'true' && steps.branch.outputs.skip != 'true'`.

Now duplicate runs short-circuit cleanly and the job ends green.

## Validation

- \`yamllint\` ✅
- \`actionlint\` ✅

Note: the existing `2026a` update PR #148 is unaffected by this change; once it is merged the workflow will report "No update needed" normally.