### PR TITLE
Add concurrency to PR-triggered CI workflows and update base image version

### DIFF
--- a/.github/workflows/ai-reviewer.yml
+++ b/.github/workflows/ai-reviewer.yml
@@ -12,6 +12,10 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   academic-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/latex-build.yml
+++ b/.github/workflows/latex-build.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,10 @@ on:
     branches: [main]
     paths: ['.github/workflows/**', '.yamllint.yml']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ textlint --fix *.tex          # Auto-fix issues where possible
 - **TeXLive 2025** with full Japanese support (uplatex/platex)
 - **textlint** for Japanese academic writing style checking
 - **VSCode devcontainer** with LaTeX Workshop and TeXLab
-- **Base image**: `ghcr.io/smkwlab/texlive-ja-textlint:2025b`
+- **Base image**: `ghcr.io/smkwlab/texlive-ja-textlint:2026a` (source of truth: `.devcontainer/devcontainer.json`)
 
 ## Key Files & Structure
 


### PR DESCRIPTION
resolve #150

## 1. concurrency 制御の追加（性能・コスト）

PR トリガーかつ途中キャンセルが安全な3本に追加しました:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
- `latex-build.yml`（PR + tag push）
- `ai-reviewer.yml`（PR + workflow_dispatch）
- `lint.yml`（PR + push main）

連続 push 時に古い実行をキャンセルし、Actions 実行時間を節約します。tag push は ref がユニークなためリリースビルドは互いに/PRビルドをキャンセルしません。

### 意図的に除外したワークフロー
以下は `cancel-in-progress` が**有害**なため追加していません:
- `branch-cleanup.yml` / `pr-auto-cleanup.yml`: PR クローズ時の後始末（途中キャンセル不可）
- `check-texlive-updates.yml`: cron（同時実行・連続 push の概念がない）
- `update-release-branch.yml`: `push: main` のリリース系。途中キャンセルは release branch を破損し得る

## 2. CLAUDE.md のベースイメージ版数

`CLAUDE.md:27` を `2025b` → `2026a` に更新し、「版数の正は `.devcontainer/devcontainer.json`」と明記して今後の乖離を防止。

## 検証
- ✅ 3ワークフローに concurrency 追加、YAML エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)