### PR TITLE
Remove font family and redundant editor settings from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,14 +2,13 @@
   // Compatible with texlive-ja-textlint: 2026a (TeXLive 2026)
   "name": "LaTeX Environment",
   "image": "ghcr.io/smkwlab/texlive-ja-textlint:2026a",
-  
+
   "remoteUser": "root",
-  
+
   "customizations": {
     "vscode": {
       "settings": {
         "textlint.nodePath": "/npm/node_modules",
-        "editor.fontFamily": "HackGen, 'BIZ UDPGothic', Meiryo, 'Hiragino Kaku Gothic ProN', 'SF Mono', Consolas, monospace",
         "editor.fontSize": 14,
         "editor.lineHeight": 1.6,
         "editor.wordWrap": "on",
@@ -19,11 +18,8 @@
         "latex-workshop.latex.watch.delay": 1000,
         "terminal.integrated.defaultProfile.linux": "bash",
         "terminal.integrated.fontSize": 14,
-        "terminal.integrated.fontFamily": "HackGen, 'BIZ UDPGothic', Meiryo, 'Hiragino Kaku Gothic ProN', 'SF Mono', Consolas, monospace",
         "git.enableSmartCommit": true,
-        "git.confirmSync": false,
-        "workbench.colorTheme": "Default Light+",
-        "window.zoomLevel": 0
+        "git.confirmSync": false
       },
 
       "extensions": [


### PR DESCRIPTION
## 概要

`.devcontainer/devcontainer.json` の VS Code 設定から、ホスト環境・個人の好みに委ねるべきフォント関連設定などを削除します。

## 変更内容

- **`editor.fontFamily` / `terminal.integrated.fontFamily` を削除**
  - フォント描画はコンテナ内(Linux)ではなくホスト側(macOS/Windows 上の VS Code)で行われ、列挙していたフォント(例: `HackGen`)はホストに標準インストールされていないため確実には効かない。
  - 未指定にすることで、各 OS が適切な等幅フォントを自動選択し、ユーザー個人のフォント設定も尊重される。
- **`window.zoomLevel: 0` を削除**
  - 既定値そのままで明示する意味がない。
- **`workbench.colorTheme` を削除**
  - テーマを固定せず、ユーザーの好みに委ねる。
- **末尾の空白(trailing whitespace)を除去**

## 補足

`editor.fontSize` / `terminal.integrated.fontSize` / `editor.lineHeight` / `editor.wordWrap` などは、ホスト依存ではなく学習環境の見た目を揃える価値があるため残しています。